### PR TITLE
Workaround to fix error from rollup: module.getExports is not a function

### DIFF
--- a/generators/app/templates/gulp_tasks/systemjs.js
+++ b/generators/app/templates/gulp_tasks/systemjs.js
@@ -21,9 +21,15 @@ function systemjs(done) {
       'github:*/*.json'
     ]
   });
+<% if (framework === 'angular1' && modules === 'systemjs' && js === 'typescript') { -%>
+  const opts = {rollup: false};
+<% } else { -%>
+  const opts = {};
+<% } -%>
   builder.buildStatic(
     <%- entry %>,
-    conf.path.tmp('index.js')
+    conf.path.tmp('index.js'),
+    opts
   ).then(() => done(), done);
 }
 


### PR DESCRIPTION
Workaround for https://github.com/jspm/jspm-cli/issues/1760 