### PR TITLE
Remove jspm scripts on build

### DIFF
--- a/generators/app/templates/gulp_tasks/systemjs.js
+++ b/generators/app/templates/gulp_tasks/systemjs.js
@@ -30,7 +30,7 @@ function systemjs(done) {
 function updateIndexHtml() {
   return gulp.src(conf.path.src('index.html'))
     .pipe(replace(
-      /<script>\n\s*System.import.*\n\s*<\/script>/,
+      /<script src="jspm_packages\/system.js">[\s\S]*System.import.*\n\s*<\/script>/,
       `<script src="index.js"></script>`
     ))
     .pipe(gulp.dest(conf.path.tmp()));


### PR DESCRIPTION
https://github.com/FountainJS/generator-fountain-webapp/issues/22