### PR TITLE
Keep using systemjs-builder for angular1

### DIFF
--- a/generators/app/templates/gulp_tasks/systemjs.js
+++ b/generators/app/templates/gulp_tasks/systemjs.js
@@ -1,8 +1,11 @@
 const gulp = require('gulp');
 const replace = require('gulp-replace');
 
+<% if (framework === 'angular1') { -%>
+const Builder = require('systemjs-builder');
+<% } else { -%>
 const Builder = require('jspm').Builder;
-
+<% } -%>
 const conf = require('../conf/gulp.conf');
 
 gulp.task('systemjs', systemjs);


### PR DESCRIPTION
This workaround fixes an issue on angular1 when running `gulp serve:dist`