### PR TITLE
Fix/jspm version

### DIFF
--- a/generators/app/conf.js
+++ b/generators/app/conf.js
@@ -13,6 +13,7 @@ module.exports = function systemConf(options) {
     if (options.framework === 'angular2') {
       conf.babelOptions = {
         plugins: [
+          'babel-plugin-transform-es2015-typeof-symbol',
           'babel-plugin-angular2-annotations',
           'babel-plugin-transform-decorators-legacy',
           'babel-plugin-transform-class-properties',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -43,7 +43,7 @@ module.exports = fountain.Base.extend({
 
       this.mergeJson('package.json', {
         devDependencies: {
-          'jspm': '^0.17.0-beta.9',
+          'jspm': 'jspm/jspm#6c85e03c9bfee63bf17408b483b15b444b7f1ada',
           'systemjs-builder': '^0.15.15',
           'gulp-replace': '^0.5.4'
         },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -54,9 +54,8 @@ module.exports = fountain.Base.extend({
     },
 
     configjs() {
-      if (this.options.modules === 'systemjs') {
-        this.copyTemplate('jspm.test.js', 'jspm.test.js');
-      }
+      this.copyTemplate('jspm.test.js', 'jspm.test.js');
+      this.copyTemplate('jspm.browser.js', 'jspm.browser.js');
       this.copyTemplate('jspm.config.js', 'jspm.config.js', {
         systemConf: conf(this.options)
       });

--- a/generators/app/templates/jspm.browser.js
+++ b/generators/app/templates/jspm.browser.js
@@ -1,0 +1,6 @@
+SystemJS.config({
+  paths: {
+    "github:*": "/jspm_packages/github/*",
+    "npm:*": "/jspm_packages/npm/*"
+  }
+});

--- a/generators/app/transforms.js
+++ b/generators/app/transforms.js
@@ -6,6 +6,11 @@ module.exports = function transforms() {
     let result = content.replace(/import '.*ss';\n\n?/g, '');
     // remove commonjs webpack styles requires
     result = result.replace(/require\('.*ss'\);\n\n?/g, '');
+    // replace commonjs function imports with es2015 imports
+    result = result.replace(
+      /var (.*) = require\(('.*')\).(.*);/g,
+      'import {$1} from $2;'
+    );
     // replace commonjs with es2015 imports
     result = result.replace(
       /var (.*) = require\(('.*')\);/g,


### PR DESCRIPTION
The third commit (`a0f0a82`) fixes an issue when having commonjs imports such as `var createStore = require('redux').createStore;`. This used to be transformed by a regex into `import createStore from 'redux'` but it has to be `import {createStore} from 'redux';`.