### PR TITLE
Set browser:true

### DIFF
--- a/generators/app/templates/gulp_tasks/systemjs.js
+++ b/generators/app/templates/gulp_tasks/systemjs.js
@@ -27,7 +27,10 @@ function systemjs(done) {
   builder.buildStatic(
     <%- entry %>,
     conf.path.tmp('index.js'),
-    {production: true}
+    {
+      production: true,
+      browser: true
+    }
   ).then(() => done(), done);
 }
 


### PR DESCRIPTION
This allows to use `Object.assign` and `es6-shim` with ES5...