### PR TITLE
Handle windows \r in transform regex and fix SystemJS build error

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -72,14 +72,18 @@ module.exports = fountain.Base.extend({
 
     gulp() {
       const extensions = this.getExtensions(this.options);
+      let baseUrl = `'./'`;
+      let configPath = `'jspm.config.js'`;
       let entry = `conf.path.src('index.${extensions.js}')`;
       if (this.options.framework === 'angular1') {
         entry = `\`\${${entry}} + \${conf.path.tmp('templateCacheHtml.${extensions.js}')}\``;
       }
       if (this.options.framework === 'angular2') {
-        entry = `conf.path.tmp('templates/index.${extensions.js}')`;
+        baseUrl = `conf.path.tmp('templates')`;
+        configPath = `'../../jspm.config.js'`;
+        entry = `'index.${extensions.js}'`;
       }
-      this.copyTemplate('gulp_tasks', 'gulp_tasks', {entry, extensions});
+      this.copyTemplate('gulp_tasks', 'gulp_tasks', {entry, baseUrl, configPath, extensions});
     },
 
     indexHtml() {

--- a/generators/app/templates/gulp_tasks/systemjs.js
+++ b/generators/app/templates/gulp_tasks/systemjs.js
@@ -20,7 +20,7 @@ gulp.task('systemjs', systemjs);
 gulp.task('systemjs:html', updateIndexHtml);
 
 function systemjs(done) {
-  const builder = new Builder('./', 'jspm.config.js');
+  const builder = new Builder(<%- baseUrl %>, 'jspm.config.js');
   builder.config({
     paths: {
       "github:*": "jspm_packages/github/*",
@@ -58,7 +58,7 @@ function replaceTemplates() {
 function updateIndexHtml() {
   return gulp.src(conf.path.src('index.html'))
     .pipe(replace(
-      /<script src="jspm_packages\/system.js">[\s\S]*System.import.*\n\s*<\/script>/,
+      /<script src="jspm_packages\/system.js">[\s\S]*System.import.*\r?\n\s*<\/script>/,
       `<script src="index.js"></script>`
     ))
 <% if (framework === 'angular2') { -%>

--- a/generators/app/transforms.js
+++ b/generators/app/transforms.js
@@ -5,28 +5,28 @@ module.exports = function transforms() {
     // replace first occurence of commonjs require of react-router module;
     let result = content.replace(/var ((\w)+) = require\('react-router'\).((\w)+);/, `import {Router, Route, browserHistory} from 'react-router';`);
     // remove other occurences of commonjs require of react-router module
-    result = result.replace(/var (.*) = require\(('react-router')\).(.*);\n?/g, '');
+    result = result.replace(/var (.*) = require\(('react-router')\).(.*);\r?\n?/g, '');
     // remove es2015 webpack styles imports
-    result = result.replace(/import '.*(styl|.*ss)';\n\n?/g, '');
+    result = result.replace(/import '.*(styl|.*ss)';\r?\n\r?\n?/g, '');
     // remove commonjs webpack styles requires
-    result = result.replace(/require\('.*(styl|.*ss)'\);\n\n?/g, '');
+    result = result.replace(/require\('.*(styl|.*ss)'\);\r?\n\r?\n?/g, '');
     // replace commonjs function imports with es2015 imports
     result = result.replace(
-      /(^|\n)var (.*) = require\(('.*')\).(.*);/g,
+      /(^|\r?\n)var (.*) = require\(('.*')\).(.*);/g,
       '$1import {$2} from $3;'
     );
     // replace commonjs with es2015 imports
     result = result.replace(
-      /(^|\n)var (.*) = require\(('.*')\);/g,
+      /(^|\r?\n)var (.*) = require\(('.*')\);/g,
       '$1import $2 from $3;'
     );
     result = result.replace(
-      /(^|\n)require\(('.*')\);/g,
+      /(^|\r?\n)require\(('.*')\);/g,
       '$1import $2;'
     );
     // replace commonjs conditional require by System.import
     result = result.replace(
-      /(^|\n)(\s+)require\(('.*')\);/g,
+      /(^|\r?\n)(\s+)require\(('.*')\);/g,
       '$1$2System.import($3);'
     );
     // replace imports to add extension


### PR DESCRIPTION
Fix https://github.com/FountainJS/generator-fountain-angular2/issues/98

Strangely only on Windows, System builder considers relative url to start from System builder base URL. With Angular 2, we use an inline html plugin which copy the sources in `.tmp/templates`. Then, relatives path failed. I moved base URL to templates folder to make it works.